### PR TITLE
Added details on Micro BOSH CLI Deployer and and vSphere CPI

### DIFF
--- a/details/micro-bosh-deployment-manifest.md
+++ b/details/micro-bosh-deployment-manifest.md
@@ -1,0 +1,9 @@
+# Details of Micro BOSH Deployment Manifest
+
+The Micro BOSH Deployment Manifest is simply a subset of a [Deployment Manifest](deployment-manifest.md).
+
+Unlike other deployment manifests, there are only 3 top-level properties (ex. [micro_bosh.yml](../examples/microbosh/micro_bosh.yml)). The Micro BOSH deployment manifest is used when [deploying from the BOSH CLI Deployer](https://github.com/cloudfoundry/oss-docs/blob/master/bosh/documentation/documentation.md), as opposed to using the [Chef installation](../creating-a-bosh-from-scratch.md).
+
+* `name` - expected deployment name
+* `networks` - Network information about the Micro BOSH (such as IP, DNS, etc.)
+* `cloud` - IaaS properties to be used for this deployment (See AWS API or [vSphere CPI](vsphere-cpi.md))

--- a/details/vsphere-cpi.md
+++ b/details/vsphere-cpi.md
@@ -1,0 +1,45 @@
+# VMware vSphere CPI
+
+The vSphere CPI is used to deploy releases to VMware vSphere clusters. In the deployment manifest, the top-level property `cloud` is used to define the IaaS properties, in this case, vSphere.
+
+Below is a detailed outline of a `cloud` section of a deployment manifest
+
+`
+cloud:
+  plugin: vsphere
+  properties:
+    agent:
+      ntp:
+       - [NTP Server #1]
+       - [NTP Server #2]
+    vcenters:
+      - host: [vCenter Server IP Address]
+        user: [Username to login to vCenter with (Ex. "DOMAIN\Username")]
+        password: [Password for above account]
+        datacenters:
+          - name: [Name of Datacenter in vCenter]
+            vm_folder: [Folder for VMs]
+            template_folder: [Folder for Stemcells]
+            disk_path: [Path in datastore to store VMs]
+            datastore_pattern: [Pattern to match datastore name(s) (Ex. las01-.*)]
+            persistent_datastore_pattern: [Pattern to match datastore name(s) for persistent disks (Ex. las01-.*)]
+            allow_mixed_datastores: [False to separate persistent/non-persistent disks, otherwise True]
+            clusters:
+              - [Name of cluster in above datacenter (Ex. CLUSTER01)]
+				resource_pool: [Optional: Resource pool to store VMs]
+`
+
+
+
+## Preparing vSphere for deployments
+
+There is a tiny bit of prep work that needs to be done before deployments can be made to vSphere. This is documented in VMware's [oss-docs](https://github.com/cloudfoundry/oss-docs/blob/master/bosh/documentation/documentation.md), but just for clarification:
+
+* Create a folder in "VMs and Templates" to match `vm_folder`
+* Create a folder in "VMs and Templates" to match `template_folder`
+* Create the `disk_path` in all datastores that match the patterns in `datastore_pattern` and `persistent_datastore_pattern`
+* If `resource_pool` is defined, create the resource pool
+* The `user` account must be created and granted the proper permissions in vCenter. See: VMware's [oss-docs](https://github.com/cloudfoundry/oss-docs/blob/master/bosh/documentation/documentation.md) under "vCenter Configuration"
+
+Once this is done, the vSphere CPI may be used to deploy releases
+

--- a/examples/microbosh/micro_bosh.yml
+++ b/examples/microbosh/micro_bosh.yml
@@ -1,0 +1,35 @@
+---
+name: bosh-bootstrap-dev33
+
+#XXX using dev33
+network:
+  ip: 172.23.194.100
+  netmask: 255.255.254.0
+  gateway: 172.23.194.1
+  dns:
+  - 172.22.22.153
+  - 172.22.22.154
+  cloud_properties:
+    name: VLAN2194
+
+cloud:
+  plugin: vsphere
+  properties:
+    agent:
+      ntp:
+       - ntp01.las01.emcatmos.com
+       - ntp02.las01.emcatmos.com
+    vcenters:
+      - host: 172.23.128.96
+        user: dev\cloudfoundry-auth
+        password: TempP@ss
+        datacenters:
+          - name: LAS01
+            vm_folder: BOSH_VMs
+            template_folder: BOSH_Templates
+            disk_path: BOSH_Deployer
+            datastore_pattern: las01-.*
+            persistent_datastore_pattern: las01-.*
+            allow_mixed_datastores: true
+            clusters:
+              - CLUSTER01


### PR DESCRIPTION
Added some descriptions to the vSphere CPI and micro_bosh.yml used when deploying Micro BOSH from the BOSH CLI. Referenced VMware docs where things were already documented, but put some definitions around some of the cloud config items.
